### PR TITLE
mainブランチ以外へのPR時に自動でテストデプロイされるのを中止するファイルを作成

### DIFF
--- a/vercel-ignore-build-step.sh
+++ b/vercel-ignore-build-step.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+echo "VERCEL_GIT_COMMIT_REF: $VERCEL_GIT_COMMIT_REF"
+
+if [[ "$VERCEL_GIT_COMMIT_REF" == "develop" ]] ; then
+  # Proceed with the build
+  echo "✅ - Build can proceed"
+  exit 1;
+
+else
+  # Don't build
+  echo "🛑 - Build cancelled"
+  exit 0;
+fi

--- a/vercel-ignore-build-step.sh
+++ b/vercel-ignore-build-step.sh
@@ -2,7 +2,7 @@
 
 echo "VERCEL_GIT_COMMIT_REF: $VERCEL_GIT_COMMIT_REF"
 
-if [[ "$VERCEL_GIT_COMMIT_REF" == "develop" ]] ; then
+if [[ "$VERCEL_GIT_COMMIT_REF" == "main" ]] ; then
   # Proceed with the build
   echo "✅ - Build can proceed"
   exit 1;


### PR DESCRIPTION
vercel-ignore-build-step.shファイルを作成し、その中にmainブランチにPRされた時にのみテストデプロイを実行する旨を記載。
Vercelのダッシュボードでvercel-ignore-build-step.shファイルを実行することで、テストデプロイを中止する。